### PR TITLE
🚨 Fix: 필터링 적용 후에 정렬하면 필터링 초기화 되는 버그 수정 및 페이지네이션 필터링 유지하도록 구현

### DIFF
--- a/src/components/layout/Search.vue
+++ b/src/components/layout/Search.vue
@@ -145,7 +145,7 @@ onBeforeUnmount(() => {
             v-model="startDate"
             class="w-[116px] h-6"
             id="startTime"
-            :max-date="new Date(endDate)"
+            :max-date="endDate ? new Date(endDate) : new Date()"
             dateFormat="yy-mm-dd"
             showButtonBar
           />

--- a/src/pages/problem-board/ProblemBoard.vue
+++ b/src/pages/problem-board/ProblemBoard.vue
@@ -23,7 +23,6 @@ const search = async (
   sort = SORT.latest,
   status,
 ) => {
-  console.log(status);
   problems.value = await problemAPI.search(
     user.value.id,
     keyword,

--- a/src/pages/problem-set-board/ProblemSetBoard.vue
+++ b/src/pages/problem-set-board/ProblemSetBoard.vue
@@ -1,6 +1,6 @@
 <script setup>
 import Search from "@/components/layout/Search.vue";
-import { ref, watchEffect, computed, watch, onBeforeMount } from "vue";
+import { ref, computed, watch, onMounted } from "vue";
 import { Paginator, Select } from "primevue";
 import ProblemSet from "@/components/layout/ProblemSet.vue";
 import { SORT, SORTS } from "@/const/sorts";
@@ -36,7 +36,7 @@ const sortedProblemSets = computed(() => {
   }
 });
 
-const search = async (keyword, startDate, endDate, sort) => {
+const search = async (keyword, startDate, endDate, sort = SORT.latest) => {
   first.value = 0;
   problemSets.value = await workbookAPI.search(
     keyword,
@@ -49,20 +49,21 @@ const search = async (keyword, startDate, endDate, sort) => {
       keyword,
       startDate: formatDate(startDate),
       endDate: formatDate(endDate),
-      sort: sort.value,
+      sort,
     },
   });
 };
 
-onBeforeMount(async () => {
+onMounted(async () => {
   problemSets.value = await workbookAPI.search(keyword, startDate, endDate);
 });
 
 watch(
-  () => sort.value,
+  () => sort.value.value,
   () => {
     first.value = 0;
-    search(keyword, startDate, endDate, sort.value);
+    const { keyword, startDate, endDate } = route.query;
+    search(keyword, startDate, endDate, sort.value.value);
   },
 );
 </script>


### PR DESCRIPTION
<!-- 반영한 브랜치 표시 확인용 -->

## ✨ 반영 브랜치

`fix/problem-set-board` -> `dev`

<!-- 간단한 PR task에 대한 설명 -->

## 📝 설명

<!-- 상세 task 변경사항 체크리스트로 기술 -->

## ✅ 변경 사항

- [x] 필터링 적용 후에 정렬하면 필터링 초기화 되는 버그 수정
- [x] 상세 페이지에서 뒤로가기 하면 필터링 유지 안되는 버그 수정
- [x] 시작일이 종료일보다 이후 날짜를 선택할 수 있었던 버그 수정

<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->

## 💬 PR 포인트 & 질문사항

- PR 좀 봐주세요~~
- 어떻게 생각하시나요?

## 📷 변경사항 스크린샷

<!-- 필수는 아니지만, 변경사항을 사진으로 공유하시면 좋아요! -->

![image](https://github.com/user-attachments/assets/10b99b61-3cb3-451d-97c5-03fbecb5e948)

<!-- 이슈 필터링을 위한 url, 이슈에 관한 PR이 아니면 삭제해도 무방 -->

## 📢 이슈 정보

#141 
