### PR TITLE
🚨 Fix: 문제 수정 / 삭제 페이지 프로필 클릭 영역 수정 및 공유 버튼 삭제

### DIFF
--- a/src/pages/problem-board-update/components/ProblemBoardUpdateHeader.vue
+++ b/src/pages/problem-board-update/components/ProblemBoardUpdateHeader.vue
@@ -293,11 +293,6 @@ onMounted(async () => {
             </template>
           </MultiSelect>
 
-          <label for="shared">공개 여부</label>
-          <ToggleSwitch
-            :modelValue="editedProblem.shared"
-            @update:modelValue="handleSharedChange"
-          />
         </fieldset>
       </div>
     </form>

--- a/src/pages/problem-detail/components/CommentList.vue
+++ b/src/pages/problem-detail/components/CommentList.vue
@@ -273,7 +273,7 @@ const onPageChange = (event) => {
           <RouterLink
             :to="{ name: 'UserProfile', params: { userId: comment.uid } }"
             aria-label="유저 프로필"
-            class="flex items-center gap-2 flex-grow"
+            class="inline-flex items-center gap-2 w-fit"
           >
             <img :src="comment.avatar_url" class="rounded-full w-7 h-7" />
             <span class="font-bold">{{ comment.name }}</span>

--- a/src/pages/problem-detail/components/ProblemHeader.vue
+++ b/src/pages/problem-detail/components/ProblemHeader.vue
@@ -156,7 +156,7 @@ const routeConfig = computed(() => {
     <RouterLink
       v-if="routeConfig"
       :to="routeConfig"
-      class="flex gap-2 items-center"
+      class="inline-flex gap-2 items-center w-fit"
     >
       <Avatar
         :image="author?.avatar_url"

--- a/src/pages/problem-detail/components/ProblemHeader.vue
+++ b/src/pages/problem-detail/components/ProblemHeader.vue
@@ -184,10 +184,6 @@ const routeConfig = computed(() => {
           <span class="bg-gray-100 px-2 py-1 rounded">{{
             problem?.category?.name
           }}</span>
-          <div class="flex items-center gap-1">
-            <img :src="shareIcon" alt="공유 아이콘" class="w-4 h-4" />
-            <span>{{ problem?.shared ? "공개됨" : "미공개" }}</span>
-          </div>
           <div
             class="flex items-center gap-1 px-2 py-1 rounded-full transition"
           >


### PR DESCRIPTION
<!-- 반영한 브랜치 표시 확인용 -->

## ✨ 반영 브랜치

`feature/` -> `dev`

<!-- 간단한 PR task에 대한 설명 -->

## 📝 설명

문제 공유 기능 삭제로 공유됨 상태(문제 상세 페이지) 및 토글 버튼(문제 수정 페이지)을 제거했습니다.
문제 상세 페이지 헤더 및 댓글 영역의 프로필 클릭 영역이 넓은 문제를 수정했습니다.